### PR TITLE
Rename workbench app namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/",
-            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Cashier\\": "workbench/cashier/",
             "Workbench\\Database\\Factories\\": "workbench/database/factories/"
         }
     },

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Laravel\Paddle\Cashier;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
-use Workbench\App\Models\User;
+use Workbench\Cashier\Models\User;
 
 abstract class FeatureTestCase extends TestCase
 {

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 use Carbon\Carbon;
 use Laravel\Paddle\Customer;
 use PHPUnit\Framework\TestCase;
-use Workbench\App\Models\User;
+use Workbench\Cashier\Models\User;
 
 class CustomerTest extends TestCase
 {

--- a/workbench/cashier/Models/User.php
+++ b/workbench/cashier/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Workbench\App\Models;
+namespace Workbench\Cashier\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticable;
 use Laravel\Paddle\Billable;

--- a/workbench/database/factories/UserFactory.php
+++ b/workbench/database/factories/UserFactory.php
@@ -2,10 +2,10 @@
 
 namespace Workbench\Database\Factories;
 
-use Workbench\App\Models\User;
+use Workbench\Cashier\Models\User;
 
 /**
- * @template TModel of \Workbench\App\Models\User
+ * @template TModel of \Workbench\Cashier\Models\User
  *
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
  */


### PR DESCRIPTION
## Summary
- rename workbench app folder to cashier
- adjust Composer autoload path
- update namespaces in model, factory, and tests

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68576775b9e8832bb4539a942a8afdff